### PR TITLE
clock_gettime() is not available on macOS < 10.12

### DIFF
--- a/MacOS/apple_compat.h
+++ b/MacOS/apple_compat.h
@@ -1,0 +1,47 @@
+/*
+ * APPLE Compatibility
+ */
+
+#ifdef __APPLE__
+
+// macOS < 10.12 doesn't have clock_gettime()
+#include <time.h>
+#if !defined(CLOCK_REALTIME) && !defined(CLOCK_MONOTONIC)
+
+#define CLOCK_REALTIME  0
+#define CLOCK_MONOTONIC 6
+typedef int clockid_t;
+
+#include <sys/time.h>
+#include <mach/mach_time.h>
+
+// here to avoid problem on linking
+static inline int clock_gettime( clockid_t clk_id, struct timespec *ts )
+{
+  int ret = -1;
+  if ( ts )
+  {
+    if      ( CLOCK_REALTIME == clk_id )
+    {
+      struct timeval tv;
+      ret = gettimeofday(&tv, NULL);
+      ts->tv_sec  = tv.tv_sec;
+      ts->tv_nsec = tv.tv_usec * 1000;
+    }
+    else if ( CLOCK_MONOTONIC == clk_id )
+    {
+      const uint64_t t = mach_absolute_time();
+      mach_timebase_info_data_t timebase;
+      mach_timebase_info(&timebase);
+      const uint64_t tdiff = t * timebase.numer / timebase.denom;
+      ts->tv_sec  = tdiff / 1000000000;
+      ts->tv_nsec = tdiff % 1000000000;
+      ret = 0;
+    }
+  }
+  return ret;
+}
+
+#endif // CLOCK_REALTIME and CLOCK_MONOTONIC
+
+#endif // __APPLE__

--- a/hpsdrsim.c
+++ b/hpsdrsim.c
@@ -65,6 +65,9 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 
+#include <time.h>
+#include "MacOS/apple_compat.h"
+
 #define NEED_DUMMY_AUDIO 1
 
 #ifdef PORTAUDIO

--- a/iambic.c
+++ b/iambic.c
@@ -191,6 +191,8 @@
 #include <time.h>
 #include <sys/mman.h>
 
+#include "MacOS/apple_compat.h"
+
 #ifdef GPIO
 #include "gpio.h"
 #endif

--- a/midi2.c
+++ b/midi2.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include "midi.h"
+#include "MacOS/apple_compat.h"
 
 void NewMidiEvent(enum MIDIevent event, int channel, int note, int val) {
 

--- a/new_protocol_programmer.c
+++ b/new_protocol_programmer.c
@@ -39,6 +39,8 @@
 
 #include <gtk/gtk.h>
 
+#include "MacOS/apple_compat.h"
+
 #include "discovered.h"
 #include "new_protocol.h"
 

--- a/newhpsdrsim.c
+++ b/newhpsdrsim.c
@@ -10,6 +10,9 @@
 #include <arpa/inet.h>
 #include <math.h>
 
+#include <time.h>
+#include "MacOS/apple_compat.h"
+
 #define EXTERN extern
 #include "hpsdrsim.h"
 

--- a/rigctl.c
+++ b/rigctl.c
@@ -60,6 +60,9 @@
 
 #define NEW_PARSER
 
+#include <time.h>
+#include "MacOS/apple_compat.h"
+
 // IP stuff below
 #include <sys/socket.h>
 #include <arpa/inet.h> //inet_addr


### PR DESCRIPTION
as specified by `man 3 clock_gettime`, `clock_gettime()` is only avaible on macOS >= 10.12.
This add support for older versions.