### PR TITLE
discover an OpenHPSDR radio using the IPv4 address

### DIFF
--- a/discovered.h
+++ b/discovered.h
@@ -92,6 +92,7 @@ struct _DISCOVERED {
     int protocol;
     int device;
     int use_tcp;    // use TCP rather than UDP to connect to radio
+    uint8_t use_routing;  // use routing to connect to radio (no local IP)
     char name[64];
     int software_version;
     int status;

--- a/discovery.h
+++ b/discovery.h
@@ -17,5 +17,5 @@
 *
 */
 
-extern void discovery(void);
-extern char *ipaddr_tcp;
+extern void discovery();
+extern char *ipaddr_radio;

--- a/stemlab_discovery.c
+++ b/stemlab_discovery.c
@@ -522,10 +522,10 @@ void stemlab_discovery() {
   struct sockaddr_in netmask;
 
    fprintf(stderr,"Stripped-down STEMLAB/HAMLAB discovery...\n");
-   fprintf(stderr,"STEMLAB: using inet addr %s\n", ipaddr_tcp);
+   fprintf(stderr,"STEMLAB: using inet addr %s\n", ipaddr_radio);
    ip_address.sin_family = AF_INET;
-   if (inet_aton(ipaddr_tcp, &ip_address.sin_addr) == 0) {
-	fprintf(stderr,"StemlabDiscovery: TCP %s is invalid!\n", ipaddr_tcp);
+   if (inet_aton(ipaddr_radio, &ip_address.sin_addr) == 0) {
+	fprintf(stderr,"StemlabDiscovery: TCP %s is invalid!\n", ipaddr_radio);
 	return;
    }
 
@@ -543,7 +543,7 @@ void stemlab_discovery() {
     return;
   }
   app_list=0;
-  sprintf(txt,"http://%s",ipaddr_tcp);
+  sprintf(txt,"http://%s",ipaddr_radio);
   curl_easy_setopt(curl_handle, CURLOPT_URL, txt);
   curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT, (long) 5);
   curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, get_list_cb);
@@ -551,7 +551,7 @@ void stemlab_discovery() {
   curl_error = curl_easy_perform(curl_handle);
   curl_easy_cleanup(curl_handle);
   if (curl_error ==  CURLE_OPERATION_TIMEDOUT) {
-    sprintf(txt,"No response from web server at %s", ipaddr_tcp);
+    sprintf(txt,"No response from web server at %s", ipaddr_radio);
     status_text(txt);
     fprintf(stderr,"%s\n",txt);
   }
@@ -569,7 +569,7 @@ void stemlab_discovery() {
       fprintf(stderr, "stemlab_start: Failed to create cURL handle\n");
       return;
     }
-    sprintf(txt,"http://%s/bazaar?apps=", ipaddr_tcp);
+    sprintf(txt,"http://%s/bazaar?apps=", ipaddr_radio);
     curl_easy_setopt(curl_handle, CURLOPT_URL, txt);
     curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT, (long) 20);
     curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, app_list_cb);


### PR DESCRIPTION
Use a pre-declared IPv4 address to find the radio and connect to it
without broadcast discovery. The user can input the IPv4 in the
discovery window. If the user declared IPv4 address is empty the
discovery is disabled. Moreover, if the IP is already discovered by the
broadcast procedure the static IP is not used.

This is very useful when you use a VPN or you computer is connected to
another network (therefore is leveraging the routing mechanism).
On both cases, you need to pay attention to the firewall rules.

To maintain the interface easy to use, the TCP (aka red pitaya)
and UDP static IP input boxes are merged in a single input.