### PR TITLE
Changed filter knob response when turned counter clock wise filter ed…

### DIFF
--- a/rigctl.h
+++ b/rigctl.h
@@ -22,7 +22,9 @@ extern gboolean rigctl_debug;
 
 void launch_rigctl (void);
 int launch_serial (int id);
+void launch_andromeda (int id);
 void disable_serial (int id);
+void disable_andromeda (int id);
 
 void  close_rigctl_ports (void);
 int   rigctlGetMode(void);

--- a/rigctl_menu.c
+++ b/rigctl_menu.c
@@ -99,7 +99,11 @@ static void andromeda_cb(GtkWidget *widget, gpointer data) {
   SerialPorts[id].andromeda=gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
   if (SerialPorts[id].andromeda) {
    SerialPorts[id].baud=B9600; //fixed baud rate
-   gtk_combo_box_set_active(GTK_COMBO_BOX(widget), 1);
+   if(SerialPorts[id].enable) {
+     launch_andromeda(id);
+   }
+  } else {
+    disable_andromeda(id);
   }
 }
 #endif


### PR DESCRIPTION
…ges move to the left and when turned

clock wise filter edges move to the right. Also added launch_andromeda and disable_andromeda to correctly respond to changes in the rigctl_menu.