### PR TITLE
Corrections to new_protocol.c and saturnmain.c

### DIFF
--- a/src/new_protocol.c
+++ b/src/new_protocol.c
@@ -771,6 +771,9 @@ static void new_protocol_high_priority() {
     DDCfrequency[id] += frequency_calibration;
   }
 
+  // CW mode from the Host; disabled since pihpsdr does not use this CW option.
+  high_priority_buffer_to_radio[5] = 0x00;
+    
   if (diversity_enabled && !xmit) {
     //
     // Use frequency of first receiver for both DDC0 and DDC1

--- a/src/saturnmain.c
+++ b/src/saturnmain.c
@@ -1453,9 +1453,9 @@ void saturn_handle_general_packet(bool FromNetwork, uint8_t *PacketBuffer) {
   Byte = *(uint8_t*)(PacketBuffer + 37);              // flag bits
   EnableTimeStamp((bool)(Byte & 1));
   EnableVITA49((bool)(Byte & 2));
+  SetFreqPhaseWord((bool)(Byte & 8));
   Byte = *(uint8_t*)(PacketBuffer + 38);              // enable timeout
   HW_Timer_Enable = ((bool)(Byte & 1));
-  SetFreqPhaseWord((bool)(Byte & 8));
   Byte = *(uint8_t*)(PacketBuffer + 58);              // flag bits
   SetPAEnabled((bool)(Byte & 1));
   SetApolloEnabled((bool)(Byte & 2));


### PR DESCRIPTION
CWX mode byte got interpreted but was not set.
Freq/Phase word setting taken from wrong byte in packet.