### PR TITLE
HL2 upper frequency should be 38.4 MHz.

### DIFF
--- a/src/old_discovery.c
+++ b/src/old_discovery.c
@@ -390,7 +390,7 @@ static gpointer discover_receive_thread(gpointer data) {
             }
 
             discovered[devices].frequency_min = 0.0;
-            discovered[devices].frequency_max = 30720000.0;
+            discovered[devices].frequency_max = 38400000.0;
             break;
 
           case DEVICE_ORION2:


### PR DESCRIPTION
The upper frequency for the Hermes Lite 2 should be 38.4 MHz, not 30.72 MHz. I discovered this while configuring a 2 meter transverter for my HL2 as the pihpsdr XVTR configuration would only allow the maximum frequency to go to 146.720 MHz (assuming 28 MHz IF).

Source for 38.4 MHz: https://github.com/softerhardware/Hermes-Lite2/wiki/FAQ