### PR TITLE
Increase CTCSS level as the previous level is not recognized by various radios/repeaters

### DIFF
--- a/wdsp/TXA.c
+++ b/wdsp/TXA.c
@@ -352,7 +352,7 @@ void create_txa (int channel)
         300.0,                                      // low cutoff frequency
         3000.0,                                     // high cutoff frequency
         1,                                          // ctcss run control
-        0.10,                                       // ctcss level
+        0.20,                                       // ctcss level
         100.0,                                      // ctcss frequency
         1,                                          // run bandpass filter
         max(2048, ch[channel].dsp_size),            // number coefficients for bandpass filter


### PR DESCRIPTION
I was trying to use CTCSS with FM to get into repeaters and noticed that the repeaters I tried weren't coming back to me (whereas they did with other radios). I also could not successfully scan for the CTCSS tone with a Kenwood TH-D74 when transmitting through a dummy load. Bumping up the level from 0.10 to 0.20 seems to resolve the problem, at least in my testing.