### PR TITLE
Command line version and help option addition

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -494,6 +494,11 @@ static void activate_pihpsdr(GtkApplication *app, gpointer data) {
 }
 
 int main(int argc, char **argv) {
+  // when command line arguments are more than 1 (app name) return version or help info
+  if (argc > 1) {
+    version_info_print(argv[1]);
+    return 0;
+  } 
   GtkApplication *pihpsdr;
   int rc;
   char name[1024];

--- a/src/saturnmain.c
+++ b/src/saturnmain.c
@@ -51,10 +51,11 @@
 #include <semaphore.h>
 #include <sys/stat.h>
 
-#include "saturnregisters.h"              // register I/O for Saturn
-#include "saturndrivers.h"                      // version I/O for Saturn
+#include "saturnregisters.h"                // register I/O for Saturn
+#include "saturndrivers.h"                  // version I/O for Saturn
 #include "saturnmain.h"
 #include "saturnserver.h"
+#include "version.h"                        // FPGA version compatibility
 
 #include "discovered.h"
 #include "new_protocol.h"
@@ -73,43 +74,6 @@ extern bool saturn_server_en;
 extern bool client_enable_tx;
 extern bool ServerActive;
 extern bool MOXAsserted;
-
-//
-// For "minor" versions up to 17, there is no "major" one.
-// For "minor" version 18,  the "major" version is 1
-// With each firmware update, the "minor" version is increased (it is not reset upon advancinc the major)
-// The "major" version is increased if piHPSDR compatibility is broken
-//
-#define FIRMWARE_MIN_MINOR    8               // Minimum FPGA "minor" software version that this software requires
-#define FIRMWARE_MAX_MINOR   18               // Maximum FPGA "minor" software version that this software is tested on
-#define FIRMWARE_MIN_MAJOR    1               // Minimum FPGA "major" software version that this software requires
-#define FIRMWARE_MAX_MAJOR    1               // Minimum FPGA "major" software version that this software requires
-
-#define SDRBOARDID 1                          // Hermes
-#define SDRSWVERSION 1                        // version of this software
-#define VDISCOVERYSIZE 60                     // discovery packet
-#define VDISCOVERYREPLYSIZE 60                // reply packet
-#define VWIDEBANDSIZE 1028                    // wideband scalar samples
-#define VCONSTTXAMPLSCALEFACTOR 0x0001FFFF    // 18 bit scale value - set to 1/2 of full scale
-#define VCONSTTXAMPLSCALEFACTOR_13 0x0002000  // 18 bit scale value - set to 1/32 of full scale FWV13+
-#define VDMATRANSFERSIZE 4096
-#define VDMABUFFERSIZE 131072                 // memory buffer to reserve (4x DDC FIFO so OK)
-#define VALIGNMENT 4096                       // buffer alignment
-#define VBASE 0x1000                          // offset into I/Q buffer for DMA to start
-#define VIQSAMPLESPERFRAME 238
-#define VIQBYTESPERFRAME 6*VIQSAMPLESPERFRAME // total bytes in one outgoing frame
-#define VIQDUCSAMPLESPERFRAME 240
-
-#define VSPKSAMPLESPERFRAME 64                // samples per UDP frame
-#define VMEMWORDSPERFRAME 32                  // 8 byte writes per UDP msg
-#define VSPKSAMPLESPERMEMWORD 2               // 2 samples (each 4 bytres) per 8 byte word
-#define VDMASPKBUFFERSIZE 32768               // memory buffer to reserve
-#define VDMASPKTRANSFERSIZE 256               // write 1 message at a time
-
-#define VMICSAMPLESPERFRAME 64
-#define VDMAMICBUFFERSIZE 32768           // memory buffer to reserve
-#define VDMAMICTRANSFERSIZE 128                        // read 1 message at a time
-#define VMICPACKETSIZE 132
 
 // uncomment to display debug printouts for FPGA data over/under flows
 //#define DISPLAY_OVER_UNDER_FLOWS 1

--- a/src/saturnmain.h
+++ b/src/saturnmain.h
@@ -34,6 +34,32 @@
 
 #include "saturnregisters.h"
 
+#define SDRBOARDID 1                          // Hermes
+#define SDRSWVERSION 1                        // version of this software
+#define VDISCOVERYSIZE 60                     // discovery packet
+#define VDISCOVERYREPLYSIZE 60                // reply packet
+#define VWIDEBANDSIZE 1028                    // wideband scalar samples
+#define VCONSTTXAMPLSCALEFACTOR 0x0001FFFF    // 18 bit scale value - set to 1/2 of full scale
+#define VCONSTTXAMPLSCALEFACTOR_13 0x0002000  // 18 bit scale value - set to 1/32 of full scale FWV13+
+#define VDMATRANSFERSIZE 4096
+#define VDMABUFFERSIZE 131072                 // memory buffer to reserve (4x DDC FIFO so OK)
+#define VALIGNMENT 4096                       // buffer alignment
+#define VBASE 0x1000                          // offset into I/Q buffer for DMA to start
+#define VIQSAMPLESPERFRAME 238
+#define VIQBYTESPERFRAME 6*VIQSAMPLESPERFRAME // total bytes in one outgoing frame
+#define VIQDUCSAMPLESPERFRAME 240
+
+#define VSPKSAMPLESPERFRAME 64                // samples per UDP frame
+#define VMEMWORDSPERFRAME 32                  // 8 byte writes per UDP msg
+#define VSPKSAMPLESPERMEMWORD 2               // 2 samples (each 4 bytres) per 8 byte word
+#define VDMASPKBUFFERSIZE 32768               // memory buffer to reserve
+#define VDMASPKTRANSFERSIZE 256               // write 1 message at a time
+
+#define VMICSAMPLESPERFRAME 64
+#define VDMAMICBUFFERSIZE 32768           // memory buffer to reserve
+#define VDMAMICTRANSFERSIZE 128                        // read 1 message at a time
+#define VMICPACKETSIZE 132
+
 void saturn_discovery(void);
 void saturn_init(void);
 void saturn_register_init(void);

--- a/src/saturnserver.c
+++ b/src/saturnserver.c
@@ -629,10 +629,10 @@ void *IncomingDUCSpecific(void *arg) {                  // listener thread
 #define VSPKSAMPLESPERFRAME 64                      // samples per UDP frame
 #define VMEMWORDSPERFRAME 32                        // 8 byte writes per UDP msg
 #define VSPKSAMPLESPERMEMWORD 2                     // 2 samples (each 4 bytres) per 8 byte word
-#define VDMABUFFERSIZE 32768            // memory buffer to reserve
+#define SRVVDMABUFFERSIZE 32768            // memory buffer to reserve
 #define VALIGNMENT 4096                             // buffer alignment
 #define VBASE 0x1000                // DMA start at 4K into buffer
-#define VDMATRANSFERSIZE 256                        // write 1 message at a time
+#define SRVVDMATRANSFERSIZE 256                        // write 1 message at a time
 
 //
 // listener thread for incoming DDC (speaker) audio packets
@@ -651,7 +651,7 @@ void *IncomingSpkrAudio(void *arg) {                    // listener thread
   // variables for DMA buffer
   //
   uint8_t* SpkWriteBuffer = NULL;             // data for DMA to write to spkr
-  uint32_t SpkBufferSize = VDMABUFFERSIZE;
+  uint32_t SpkBufferSize = SRVVDMABUFFERSIZE;
   unsigned char* SpkBasePtr;                // ptr to DMA location in spk memory
   int DMAWritefile_fd = -1;               // DMA read file device
   bool FIFOOverflow, FIFOUnderflow, FIFOOverThreshold;
@@ -722,10 +722,10 @@ void *IncomingSpkrAudio(void *arg) {                    // listener thread
       }
 
       // copy data from UDP Buffer & DMA write it
-      memcpy(SpkBasePtr, UDPInBuffer + 4, VDMATRANSFERSIZE);              // copy out spk samples
+      memcpy(SpkBasePtr, UDPInBuffer + 4, SRVVDMATRANSFERSIZE);              // copy out spk samples
       //            if(RegVal == 100)
-      //                DumpMemoryBuffer(SpkBasePtr, VDMATRANSFERSIZE);
-      DMAWriteToFPGA(DMAWritefile_fd, SpkBasePtr, VDMATRANSFERSIZE, VADDRSPKRSTREAMWRITE);
+      //                DumpMemoryBuffer(SpkBasePtr, SRVVDMATRANSFERSIZE);
+      DMAWriteToFPGA(DMAWritefile_fd, SpkBasePtr, SRVVDMATRANSFERSIZE, VADDRSPKRSTREAMWRITE);
     }
   }
 
@@ -739,7 +739,6 @@ void *IncomingSpkrAudio(void *arg) {                    // listener thread
 }
 #endif
 
-#define VIQSAMPLESPERFRAME 240                      // samples per UDP frame
 #define VMEMDUCWORDSPERFRAME 180                       // memory writes per UDP frame
 #define VBYTESPERSAMPLE 6             // 24 bit + 24 bit samples
 #define VDMADUCTRANSFERSIZE 1440                       // write 1 message at a time

--- a/src/version.c
+++ b/src/version.c
@@ -15,6 +15,9 @@
 *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 *
 */
+#include <stdio.h>
+#include <string.h>
+#include "version.h"
 
 char build_date[] = GIT_DATE;
 char build_version[] = GIT_VERSION;
@@ -60,3 +63,43 @@ char build_audio[] =
 #if !defined(ALSA) && !defined(PORTAUDIO) && !defined(PULSEAUDIO)
   "(unkown)";
 #endif
+
+void version_info_print(char * cmdlp) {
+  int copts = 0;
+  if (!(strcmp(cmdlp,"-V")) || !(strcmp(cmdlp,"--version"))) {
+    printf("Pihpsdr\n"); 
+    printf("git_commit: %s\n", GIT_COMMIT);
+    printf("git_date: %s\n", GIT_DATE);
+    printf("fpga_min: %d.%d\n", FIRMWARE_MIN_MAJOR,FIRMWARE_MIN_MINOR);
+    printf("fpga_max: %d.%d\n", FIRMWARE_MAX_MAJOR,FIRMWARE_MAX_MINOR);
+#ifdef GPIO
+    copts += 0x01;
+#endif 
+#ifdef MIDI
+    copts += 0x02;
+#endif 
+#ifdef SATURN
+    copts += 0x04;
+#endif 
+#ifdef EXTNR
+    copts += 0x08;
+#endif
+#ifdef SERVER
+    copts += 0x10;
+#endif
+#ifdef ALSA
+    copts += 0x20;
+#endif 
+#ifdef PULSEAUDIO
+    copts += 0x40;
+#endif
+#ifdef PORTAUDIO
+    copts += 0x80;
+#endif
+  printf("options: 0x%x\n", copts);
+  } else { // give help info
+    printf("Regular start of Pihpsdr is without command line parameters!\n");
+    printf("\'pihpsdr -V | --version\' returns version information.\n");
+    printf("\'pihpsdr <something>' returns this help information.\n"); 
+  }
+}

--- a/src/version.h
+++ b/src/version.h
@@ -25,4 +25,17 @@ extern char build_commit[];
 extern char build_options[];
 extern char build_audio[];
 
+void version_info_print(char * cmdlp);
+
+//
+// For "minor" versions up to 17, there is no "major" one.
+// For "minor" version 18,  the "major" version is 1
+// With each firmware update, the "minor" version is increased (it is not reset upon advancinc the major)
+// The "major" version is increased if piHPSDR compatibility is broken
+//
+#define FIRMWARE_MIN_MINOR    8 // Minimum FPGA "minor" software version that this software requires
+#define FIRMWARE_MAX_MINOR   18 // Maximum FPGA "minor" software version that this software is tested on
+#define FIRMWARE_MIN_MAJOR    1 // Minimum FPGA "major" software version that this software requires
+#define FIRMWARE_MAX_MAJOR    1 // Minimum FPGA "major" software version that this software requires
+
 #endif


### PR DESCRIPTION
To facilitate automatic update of multiple applications in a Software Defined Radio it is useful to be able to know the version of the installed Pihpsdr, its compile options, and its FPGA compatibility without interfering with a possibly running instance of Pihpsdr.
Invoking pihpsdr with -V or --version will make the program send version info to stdout.
Some of the Saturn specific version info was moved to version.h. The compiler also discovered some double and conflicting #define in saturnmain.c and saturnserver.c. The ones used in the server got SRV in the name prepended.     