### PR TITLE
client_server: fix off-by-one array usage in generate_pwd_hash()

### DIFF
--- a/src/client_server.c
+++ b/src/client_server.c
@@ -225,10 +225,10 @@ static void generate_pwd_hash(unsigned char *s, unsigned char *hash, const char 
   //
   // Add version number to the challenge
   //
-  s[SHA512_DIGEST_LENGTH + 1] = (CLIENT_SERVER_VERSION >> 24) & 0xFF;
-  s[SHA512_DIGEST_LENGTH + 2] = (CLIENT_SERVER_VERSION >> 16) & 0xFF;
-  s[SHA512_DIGEST_LENGTH + 3] = (CLIENT_SERVER_VERSION >>  8) & 0xFF;
-  s[SHA512_DIGEST_LENGTH + 4] = (CLIENT_SERVER_VERSION >>  0) & 0xFF;
+  s[SHA512_DIGEST_LENGTH]     = (CLIENT_SERVER_VERSION >> 24) & 0xFF;
+  s[SHA512_DIGEST_LENGTH + 1] = (CLIENT_SERVER_VERSION >> 16) & 0xFF;
+  s[SHA512_DIGEST_LENGTH + 2] = (CLIENT_SERVER_VERSION >>  8) & 0xFF;
+  s[SHA512_DIGEST_LENGTH + 3] = (CLIENT_SERVER_VERSION >>  0) & 0xFF;
   int pwdlen = strlen(pwd);
 
   if (pwdlen > SHA512_DIGEST_LENGTH) { pwdlen = SHA512_DIGEST_LENGTH; }
@@ -237,7 +237,7 @@ static void generate_pwd_hash(unsigned char *s, unsigned char *hash, const char 
   // Add password to the challenge
   //
   for  (int i = 0; i < pwdlen; i++) {
-    s[SHA512_DIGEST_LENGTH + 5 + i] = pwd[i];
+    s[SHA512_DIGEST_LENGTH + 4 + i] = pwd[i];
   }
 
   //
@@ -254,13 +254,13 @@ static void generate_pwd_hash(unsigned char *s, unsigned char *hash, const char 
       s[j] = hash[j];
     }
 
-    s[SHA512_DIGEST_LENGTH + 1] = (CLIENT_SERVER_VERSION >> 24) & 0xFF;
-    s[SHA512_DIGEST_LENGTH + 2] = (CLIENT_SERVER_VERSION >> 16) & 0xFF;
-    s[SHA512_DIGEST_LENGTH + 3] = (CLIENT_SERVER_VERSION >>  8) & 0xFF;
-    s[SHA512_DIGEST_LENGTH + 4] = (CLIENT_SERVER_VERSION >>  0) & 0xFF;
+    s[SHA512_DIGEST_LENGTH]     = (CLIENT_SERVER_VERSION >> 24) & 0xFF;
+    s[SHA512_DIGEST_LENGTH + 1] = (CLIENT_SERVER_VERSION >> 16) & 0xFF;
+    s[SHA512_DIGEST_LENGTH + 2] = (CLIENT_SERVER_VERSION >>  8) & 0xFF;
+    s[SHA512_DIGEST_LENGTH + 3] = (CLIENT_SERVER_VERSION >>  0) & 0xFF;
 
     for  (int j = 0; j < pwdlen; j++) {
-      s[SHA512_DIGEST_LENGTH + 5 + j] = pwd[j];
+      s[SHA512_DIGEST_LENGTH + 4 + j] = pwd[j];
     }
 
     //


### PR DESCRIPTION
array in C starts at 0 index therefore the last value is LENGTH-1.
It was working because some OSes memset() to zero the `s` array but this is not guaranteed by C standard and in fact if you have garbage in `s` the authentication will fail. Moreover, if the password is greater or equal to SHA512_DIGEST_LENGTH a segmentation fault will arise since array access is out of bound (64+64+5 > 2*64+4); see line 240.