### PR TITLE
Xdma by prandr

### DIFF
--- a/src/saturndrivers.c
+++ b/src/saturndrivers.c
@@ -108,7 +108,7 @@ unsigned int GetFirmwareMajorVersion(void) {
 
 //
 // initiate a DMA to the FPGA with specified parameters
-// returns 1 if success, else 0
+// returns 0 if success, else -EIO
 // fd: file device (an open file)
 // SrcData: pointer to memory block to transfer
 // Length: number of bytes to copy
@@ -118,16 +118,9 @@ int DMAWriteToFPGA(int fd, unsigned char*SrcData, uint32_t Length, uint32_t AXIA
   ssize_t rc;                 // response code
   off_t OffsetAddr;
   OffsetAddr = AXIAddr;
-  rc = lseek(fd, OffsetAddr, SEEK_SET);
-
-  if (rc != OffsetAddr) {
-    t_print("seek off 0x%lx != 0x%lx.\n", rc, OffsetAddr);
-    t_perror("seek file");
-    return -EIO;
-  }
 
   // write data to FPGA from memory buffer
-  rc = write(fd, SrcData, Length);
+  rc = pwrite(fd, SrcData, Length, OffsetAddr);
 
   if (rc < 0) {
     t_print("write 0x%x @ 0x%lx failed %ld.\n", Length, OffsetAddr, rc);
@@ -140,7 +133,7 @@ int DMAWriteToFPGA(int fd, unsigned char*SrcData, uint32_t Length, uint32_t AXIA
 
 //
 // initiate a DMA from the FPGA with specified parameters
-// returns 1 if success, else 0
+// returns 0 if success, else -EIO
 // fd: file device (an open file)
 // DestData: pointer to memory block to transfer
 // Length: number of bytes to copy
@@ -150,16 +143,9 @@ int DMAReadFromFPGA(int fd, unsigned char*DestData, uint32_t Length, uint32_t AX
   ssize_t rc;                 // response code
   off_t OffsetAddr;
   OffsetAddr = AXIAddr;
-  rc = lseek(fd, OffsetAddr, SEEK_SET);
 
-  if (rc != OffsetAddr) {
-    t_print("seek off 0x%lx != 0x%lx.\n", rc, OffsetAddr);
-    t_perror("seek file");
-    return -EIO;
-  }
-
-  // write data to FPGA from memory buffer
-  rc = read(fd, DestData, Length);
+  // read data from FPGA to memory buffer
+  rc = pread(fd, DestData, Length, OffsetAddr);
 
   if (rc < 0) {
     t_print("read 0x%x @ 0x%lx failed %ld.\n", Length, OffsetAddr, rc);

--- a/src/saturnmain.c
+++ b/src/saturnmain.c
@@ -482,7 +482,7 @@ static void saturn_init_duc_iq() {
   //
   // open DMA device driver
   //
-  DMADUCWritefile_fd = open(VDUCDMADEVICE, O_RDWR);
+  DMADUCWritefile_fd = open(VDUCDMADEVICE, O_WRONLY);
 
   if (DMADUCWritefile_fd < 0) {
     t_print("%s: XDMA write device open failed for TX I/Q data\n", __FUNCTION__);
@@ -596,7 +596,7 @@ static void saturn_init_speaker_audio() {
   //
   // open DMA device driver
   //
-  DMASpkWritefile_fd = open(VSPKDMADEVICE, O_RDWR);
+  DMASpkWritefile_fd = open(VSPKDMADEVICE, O_WRONLY);
 
   if (DMASpkWritefile_fd < 0) {
     t_print("%s: XDMA write device open failed for spk data\n", __FUNCTION__);
@@ -863,7 +863,7 @@ static gpointer saturn_micaudio_thread(gpointer arg) {
   //
   // open DMA device driver
   //
-  DMAReadfile_fd = open(VMICDMADEVICE, O_RDWR);
+  DMAReadfile_fd = open(VMICDMADEVICE, O_RDONLY);
 
   if (DMAReadfile_fd < 0) {
     t_print("%s: XDMA read device open failed for mic data\n", __FUNCTION__);
@@ -1043,7 +1043,7 @@ static gpointer saturn_rx_thread(gpointer arg) {
   //
   // open DMA device driver
   //
-  IQReadfile_fd = open(VDDCDMADEVICE, O_RDWR);
+  IQReadfile_fd = open(VDDCDMADEVICE, O_RDONLY);
 
   if (IQReadfile_fd < 0) {
     t_print("%s: XDMA read device open failed for DDC data\n", __FUNCTION__);


### PR DESCRIPTION
the xdma driver was rewritten by Prandr and this resolves a problem that occurred in an upgraded Anan G2 SDR with kernels more recent than 6.13, data getting corrupted beyond 4096 bytes. The new driver checks on C2H file handles being opened only for read, and H2C only for write. lseek() is not supported and AXI bus offset must be obtained using pread() and pwrite().
This PR adapts the Saturn specific routines in Pihpsdr to this new xdma driver.
Backwards compatibility to the old driver is expected but should be tested before PR merge.