### PR TITLE
Adding mac_install.sh to replace libinstall.sh and build_mac.sh

### DIFF
--- a/MacOS/build_mac.sh
+++ b/MacOS/build_mac.sh
@@ -1,0 +1,132 @@
+
+
+#!/bin/zsh
+
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+# Trap errors and report the line number and command that failed
+trap 'echo "❌ Error on line $LINENO: $BASH_COMMAND"; exit 1' ERR
+
+# Reminder to run mac_install.sh before proceeding
+echo "\n⚠️ Please ensure you've run mac_install.sh and it has completed all steps successfully before continuing."
+
+ # Set default values
+VERSION="REL"
+UPGRADE="n"
+
+# Use defaults if no arguments are provided
+if [[ $# -eq 0 ]]; then
+  echo "\nℹ️ No arguments provided. Using defaults: version=REL, upgrade=n"
+else
+  for arg in "$@"; do
+    case $arg in
+      version=*)
+        VERSION="${arg#*=}"
+        shift
+        ;;
+      upgrade=*)
+        UPGRADE="${arg#*=}"
+        shift
+        ;;
+      *)
+        echo "❌ Unknown argument: $arg"
+        echo "Usage: ./build_mac.sh version=REL|DEV upgrade=y|n"
+        exit 1
+        ;;
+    esac
+  done
+fi
+
+# Validate arguments
+if [[ "$VERSION" != "REL" && "$VERSION" != "DEV" ]]; then
+  echo "\n❌ Invalid version value. Use version=REL or version=DEV"
+  exit 1
+fi
+
+if [[ "$UPGRADE" != "y" && "$UPGRADE" != "n" ]]; then
+  echo "\n❌ Invalid upgrade value. Use upgrade=y or upgrade=n"
+  exit 1
+fi
+
+echo "\n🚀 Building pihpsdr with version: $VERSION and upgrade: $UPGRADE"
+
+# Perform upgrade if requested
+if [[ "$UPGRADE" == "y" ]]; then
+  echo "\n🔄 Performing git pull and submodule update..."
+  if ! git pull; then
+    echo "\n❌ Failed to pull latest changes."
+    exit 1
+  fi
+  if ! git submodule update --recursive; then
+    echo "\n❌ Failed to update submodules."
+    exit 1
+  fi
+  echo "🔧 Re-running mac_install.sh after upgrade..."
+  if ! ./mac_install.sh; then
+    echo "\n❌ mac_install.sh failed after upgrade. Aborting build."
+    exit 1
+  fi
+fi
+
+# Checkout appropriate git branch
+if [[ "$VERSION" == "REL" ]]; then
+  echo "\n📦 Checking out release branch Rel-2.4..."
+  if ! git checkout Rel-2.4; then
+    echo "\n❌ Failed to checkout Rel-2.4 branch."
+    exit 1
+  fi
+elif [[ "$VERSION" == "DEV" ]]; then
+  echo "\n📦 Checking out development branch master..."
+  if ! git checkout master; then
+    echo "\n❌ Failed to checkout master branch."
+    exit 1
+  fi
+fi
+
+
+echo "\n🧹 Running make clean..."
+if ! make clean; then
+  echo "\n❌ make clean failed."
+  exit 1
+fi
+
+echo "\n🏗️ Building application with make app..."
+if ! make app; then
+  echo "\n❌ make app failed."
+  exit 1
+fi
+
+if [[ -d "/Applications/pihpsdr.app" ]]; then
+  echo "\n⚠️ pihpsdr.app already exists in /Applications. Do you want to replace it? (y/n): "
+  read CONFIRM_DELETE
+  if [[ "$CONFIRM_DELETE" != "y" ]]; then
+    echo "🚫 Aborting installation to avoid overwriting existing application."
+    exit 0
+  fi
+  echo "\n🗑️ Removing existing pihpsdr.app from /Applications..."
+  if ! rm -rf /Applications/pihpsdr.app; then
+    echo "\n❌ Failed to remove existing pihpsdr.app from /Applications."
+    exit 1
+  fi
+fi
+echo "\n📦 Moving pihpsdr.app to /Applications..."
+if ! mv pihpsdr.app /Applications; then
+  echo "\n❌ Failed to move pihpsdr.app to /Applications."
+  exit 1
+fi
+
+# Prompt for desktop alias
+echo "\n📎 Would you like to create a desktop alias for pihpsdr.app? (y/n): "
+read CREATE_ALIAS
+if [[ "$CREATE_ALIAS" == "y" ]]; then
+  APP_PATH="/Applications/pihpsdr.app"
+  DESKTOP_PATH="$HOME/Desktop"
+
+  echo "📁 Creating desktop alias..."
+  if ! osascript -e "tell application \"Finder\" to make alias file to POSIX file \"$APP_PATH\" at POSIX file \"$DESKTOP_PATH\""; then
+    echo "❌ Failed to create desktop alias."
+    echo "💡 You can manually create an alias by dragging pihpsdr.app from /Applications to your Desktop."
+    exit 1
+  fi
+fi

--- a/MacOS/mac_install.sh
+++ b/MacOS/mac_install.sh
@@ -1,0 +1,86 @@
+#!/bin/zsh
+
+echo "🔍 Checking for XQuartz..."
+if [[ $(uname -m) == "arm64" ]]; then
+  XQUARTZ_BIN="/opt/X11/bin/Xquartz"
+else
+  XQUARTZ_BIN="/usr/X11/bin/Xquartz"
+fi
+
+if [ -x "$XQUARTZ_BIN" ]; then
+  echo "✅ XQuartz is already installed."
+else
+  echo "❌ XQuartz not found. Please download and install it from https://www.xquartz.org/ (version 2.8.5 recommended)."
+  echo "🌐 Opening download page in your browser..."
+  open "https://www.xquartz.org/"
+  echo "⏳ Once XQuartz is installed, please re-run this script."
+  exit 1
+fi
+
+echo "\n🔍 Checking for Xcode Command Line Tools..."
+if ! xcode-select -p &>/dev/null; then
+  echo "🛠️ Xcode Command Line Tools not found. Installing..."
+  xcode-select --install
+  echo "⏳ Please complete the Xcode CLI installation manually if prompted, then re-run this script."
+  exit 1
+else
+  echo "✅ Xcode Command Line Tools are already installed."
+fi
+
+echo "\n🔍 Checking for Homebrew..."
+if ! command -v brew &>/dev/null; then
+  echo "🍺 Homebrew not found. Installing..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+  # Add Homebrew to PATH based on system architecture
+  if [[ $(uname -m) == "arm64" ]]; then
+    echo "📦 Detected Apple Silicon. Setting Homebrew path for /opt/homebrew..."
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ $(uname -m) == "x86_64" ]]; then
+    echo "📦 Detected Intel. Setting Homebrew path for /usr/local..."
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+else
+  echo "✅ Homebrew is already installed."
+fi
+
+echo "\n🔄 Updating Homebrew..."
+brew update
+brew upgrade
+
+echo "\n📦 Installing required packages with Homebrew..."
+packages=(gtk+3 librsvg pkg-config portaudio fftw libusb makedepend cppcheck openssl@3 cmake python-setuptools soapysdr)
+
+for pkg in $packages; do
+  if brew list --formula | grep -q "^$pkg\$"; then
+    echo "🔁 Reinstalling $pkg..."
+    brew reinstall $pkg
+  else
+    echo "⬇️ Installing $pkg..."
+    brew install $pkg
+  fi
+done
+
+soapypackages=(pothosware/pothos/soapyplutosdr pothosware/pothos/limesuite pothosware/pothos/soapyrtlsdr pothosware/pothos/soapyairspy pothosware/pothos/soapyhackrf pothosware/pothos/soapyredpitaya)
+
+echo "\nSkipping install of SoapySDR packages as they no longer compile on the latest version of CMake and macOS Operating Systems.  Check https://github.com/pothosware/homebrew-pothos/issues to see if the issues have been resolved."
+
+echo "\nOnce the issues are resolved, open this file with TextEdit and remove the # on the lines after the \"Remove the # to enable for SoapySDR plugins\" comment."
+
+####################################################
+# Remove the # to enable for SoapySDR plugins
+####################################################
+
+# brew tap pothosware/pothos
+
+# for soapypkg in $soapypackages; do
+#   if brew list --formula | grep -q "^$soapypkg\$"; then
+#     echo "🔁 Reinstalling $soapypkg..."
+#     brew reinstall $soapypkg
+#   else
+#     echo "⬇️ Installing $soapypkg..."
+#     brew install $soapypkg
+#   fi
+# done
+
+echo "\n🎉 All done!"


### PR DESCRIPTION
I have nothing but the highest regard for the person(s) advancing this project, so please take this PR as constructive contribution to improve this effort.
As a first foray into contributing to this project, I found the scripts in the MacOS directory would not execute (failing on the first line, to be exact).  Therefore, one part of this PR is to replace the libinstall.sh script with an up-to-date version titled "mac_install.sh" with error handling and exact steps to guide the user to installing all the necessary modules for a successful compile.  I have also commented out all the SoapySDR modules as based on the issues you have filed, you are aware that these modules no longer compile on macOS with the current CMake version.  (Apparently whether this is Homebrew's issue or the maintainer of the SoapySDR casks remains unresolved).
The second shell script's purpose is to encapsulate the instructions in your manual's "compile from source for MacOS" chapter into a run-and-done capability.
I chose not to remove the existing shell scripts as that decision is left up to you, as well as the decision to accept this PR.
I am happy to make consider changes to the scripts based on your feedback, as well as address improvements/bug fixes.
