### PR TITLE
support for radioberry pi-5 pio mode

### DIFF
--- a/src/gpio.c
+++ b/src/gpio.c
@@ -1207,7 +1207,7 @@ void gpio_init() {
   // are not yet set when calling gpio_set_defaults()
   // (Thanks Yado-San for nailing this down)
   //
-  if (have_radioberry1 || have_radioberry2) {
+  if (have_radioberry1 || have_radioberry2 || have_radioberry3) {
     //
     // RadioBerry: force "No Controller" and allow for at most
     // two 'extra' lines (used for CWL/CWR input)
@@ -1232,6 +1232,12 @@ void gpio_init() {
       CWL_LINE = 17;
       CWR_LINE = 21;
       t_print("Forced RadioBerry2 GPIO settings\n");
+    }
+	
+	if (have_radioberry3) {
+      CWL_LINE = 17;
+      CWR_LINE = 13;
+      t_print("Forced RadioBerry3 GPIO settings\n");
     }
   }
 

--- a/src/radio.c
+++ b/src/radio.c
@@ -256,6 +256,7 @@ int have_g2_v2 = 0;
 int have_lime = 0;
 int have_radioberry1 = 0;
 int have_radioberry2 = 0;
+int have_radioberry3 = 0;
 int rx_gain_calibration = 0;
 
 int split = 0;
@@ -1120,11 +1121,9 @@ void radio_start_radio() {
       //
       // This is a RadioBerry.
       //
-      if (radio->software_version < 732) {
-        have_radioberry1 = 1;
-      } else {
-        have_radioberry2 = 1;
-      }
+      if (radio->software_version < 732) 		have_radioberry1 = 1; 
+	  else if (radio->software_version < 750) 	have_radioberry2 = 1;
+      else have_radioberry3 = 1;                     
     }
   }
 

--- a/src/radio.h
+++ b/src/radio.h
@@ -257,6 +257,7 @@ extern int have_g2_v2;           // G2V2 ANDROMEDA message read
 extern int have_lime;            // The radio is a LIME-SDR
 extern int have_radioberry1;     // RadioBerry with first-generation  firmware
 extern int have_radioberry2;     // RadioBerry with second-generation firmware
+extern int have_radioberry3;	 // RadioBerry with third-generation firmware (pio support)
 extern int rx_gain_calibration;  // used to calibrate the input signal
 
 extern double drive_min;         // minimum value of the drive slider


### PR DESCRIPTION
Dear Christoph,

I have done some nice development for the radioberry. Escpecially for the pi-5. As you may have seen during your work using the new io library the rpi-5 uses now a rp1 chip for doing the io. This chip is also able to use a pio using statemachines (sm)  I have done some development to use this rp1 chip using these sm and DMA in a new driver.
Resulting in a very good performing radio ; the cpu utilization is dropped amazingly.

I recorded a video:

https://www.youtube.com/watch?v=v34ROMQqOaA


To make use of these new technology i was not able to keep the same pin usages.

https://github.com/pa3gsb/Radioberry-2.x/wiki/GPIO-RPI---Radioberry 

Hope you are willing to merge the change.

73 Johan
PA3GSB