### PR TITLE
Fix CW keyer speed not applied in client/server mode

### DIFF
--- a/src/radio.c
+++ b/src/radio.c
@@ -2209,8 +2209,15 @@ void radio_load_filters(int b) {
 void radio_set_cw_speed(int val) {
   cw_keyer_speed = val;
   g_idle_add(sliders_wpm, NULL);
+  //
+  // keyer_update() must run regardless of radio_is_remote: in
+  // client/server mode the CLIENT runs its own local software
+  // iambic keyer thread (see iambic.c), and keyer_update() is what
+  // refreshes the dot/dash timing constants that thread reads.
+  // Only the direct hardware TX-buffer update is server-only.
+  //
+  keyer_update();
   if (!radio_is_remote) {
-    keyer_update();
     schedule_transmit_specific();
   }
   g_idle_add(ext_vfo_update, NULL);


### PR DESCRIPTION
## Summary

In client/server operation, changing CW speed (toolbar slider or CW menu spinbutton) on the client updates the displayed WPM value but has no effect on the actual keying speed — it stays fixed at whatever speed was in effect when the client connected. Local (standalone) operation is unaffected.

## Root cause

In client/server mode the **client** — not the server — runs the software iambic keyer (`iambic.c: keyer_thread`), started via `radio_client_start()` forcing `cw_keyer_internal = 0`. The server disables its own software keyer while a client is connected (`server_thread.c`, ~line 1133) and simply relays the already-timed key up/down events it receives via `CMD_CW` into its TX ring buffer to shape the RF envelope — it never recomputes timing itself. So keying speed is fully determined by the client's local `iambic.c` timing constants.

Those constants (`dot_length`, `dot_samples`, `dash_samples` in `iambic.c`) are cached statics, only recomputed inside `keyer_update()` from `cw_keyer_speed` / `cw_keyer_weight` (`iambic.c` ~line 284). The running `keyer_thread` never re-reads `cw_keyer_speed` directly — it only reads these cached values.

`radio_set_cw_speed()` (the single entry point for both the CW menu spinbutton and the toolbar slider) only called `keyer_update()` when `!radio_is_remote`:

```c
if (!radio_is_remote) {
  keyer_update();
  schedule_transmit_specific();
}
```

That guard was correct under the old assumption that software keying only runs locally when not acting as a client. It no longer holds: the client always runs its own local keyer thread, so on a client `keyer_update()` was never called on a speed change, and the thread kept using stale timing constants from startup/connect time.

## Fix

Call `keyer_update()` unconditionally — it's what refreshes the timing constants the client's local keyer thread reads. Keep `schedule_transmit_specific()` gated to local-only, since that writes directly into hardware TX protocol buffers only the server should touch.

`keyer_update()`'s thread start/stop branch is a no-op here: on a client `cw_keyer_internal` is forced `0` and the thread is already running, so calling it on every speed change only does the timing recompute, with no unwanted thread restarts.

No protocol/wire changes are required — `CMD_CW` already carries whatever `wait` duration the client computes; it just needed to compute the right one.

## Testing

- Builds cleanly, no new warnings.
- Standalone operation: speed slider still applies immediately (no behavior change — `keyer_update()` was already called locally before).
- Client/server: verified speed slider and CW menu spinbutton changes on the client now change both local sidetone speed and the actual relayed keying (server RF envelope), with no added paddle-to-sidetone latency, since `keyer_update()` only recomputes static timing constants and does not touch the sidetone ring-buffer path.