### PR TITLE
P2: fix ADC1 dither/random bit in diversity mode

### DIFF
--- a/src/new_protocol.c
+++ b/src/new_protocol.c
@@ -1429,8 +1429,8 @@ static void new_protocol_receive_specific(void) {
     //    The sample rate of both DDCs is that of receiver[0].
     //    Boths ADCs take the dither/random setting from ADC0
     //
-    receive_specific_buffer[5] = adc[0].dither | (adc[0].dither >> 1);
-    receive_specific_buffer[6] = adc[0].random | (adc[0].random >> 1);
+    receive_specific_buffer[5] = adc[0].dither | (adc[0].dither << 1);
+    receive_specific_buffer[6] = adc[0].random | (adc[0].random << 1);
     receive_specific_buffer[17] = 0;                                               // ADC0 associated with DDC0
     receive_specific_buffer[18] = ((receiver[0]->sample_rate / 1000) >> 8) & 0xFF; // sample rate MSB
     receive_specific_buffer[19] = ((receiver[0]->sample_rate / 1000)     ) & 0xFF; // sample rate LSB


### PR DESCRIPTION
In new_protocol_receive_specific(), the diversity override of the dither/random bytes shifts right where it should shift left. Bit 1 of receive_specific_buffer[5] and [6] is ADC1's setting - the ordinary path a few lines above builds it as "adc[0].dither | (adc[1].dither << 1)" - and adc[].dither and adc[].random are 0 or 1, so ">> 1" is always zero and ADC1's bit was permanently cleared.

The effect is that whenever dither or random was enabled, the two ADCs ran with different settings: exactly the opposite of what the comment directly above the lines says it is doing, and harmful to diversity, which depends on the two receive chains being identical.