### PR TITLE
Feature/parallel rx shutdown

### DIFF
--- a/src/radio.c
+++ b/src/radio.c
@@ -76,6 +76,18 @@
 #endif
 #include "store.h"
 #include "vfo.h"
+
+//
+// Set to 1 to time the RX->TX receiver shutdown and print the result on
+// every transition. Experimental measurement code, off in normal builds -
+// the same shape as the audio "punch" block in receiver.c.
+//
+// Deliberately a #define here rather than a -D on the command line:
+// CFLAGS is "?=" in this Makefile AND in rnnoise/Makefile, and a
+// command-line CFLAGS overrides both and propagates into every sub-make,
+// so rnnoise loses its own -Iinclude -Isrc and fails to find common.h.
+//
+#define RXTX_TIMING 1
 #include "waterfall.h"
 
 #define min(x,y) (x<y?x:y)
@@ -1811,6 +1823,23 @@ static void rxtx(int state) {
   // If running duplex, RXTX is faster since there is not
   // receiver slew-down.
   //
+  // That cost used to be per receiver, because each one was shut down and
+  // waited for in turn. The receivers are now asked to stop together and
+  // waited for afterwards - see rx_begin_off() - so it is the longest
+  // slew-down rather than the sum of them.
+  //
+  // Measured with RXTX_TIMING below, medians of three transitions:
+  //
+  //     one receiver          16.9 ms      the control
+  //     two receivers         16.8 ms      x1.00
+  //     one panel, ear split  15.8 ms      x0.94
+  //
+  // Two receivers now cost what one costs. Serialised, the two-receiver
+  // figure was two slew-downs, so this takes about 17 ms off every RX/TX
+  // turnaround with a second receiver running - which in CW is time
+  // between the key going down and the first element, iambic.c busy-waits
+  // on mox and radio_set_mox() only sets it once rxtx() has returned.
+  //
   if (transmitter == NULL) {
     t_print("%s: WARNING: rxtx called but no transmitter!", __func__);
     return;
@@ -1846,14 +1875,38 @@ static void rxtx(int state) {
       alex_forward_max = 0;
     }
     if (!duplex) {
+      //
+      // Ask every receiver to stop before waiting for any of them. The
+      // channels ramp down concurrently, so this costs the longest ramp
+      // rather than the sum - which on 2 RX is most of what the RX/TX
+      // turnaround costs, and in CW sits between the key going down and
+      // the first element. See rx_begin_off().
+      //
+      if (!radio_is_remote) {
+#if RXTX_TIMING
+        //
+        // Set RXTX_TIMING to 1 at the top of this file to measure the
+        // block the RX/TX turnaround is dominated by, and which the
+        // two-phase shutdown above is meant to shorten. Comparing 1 RX
+        // (the control), 2 RX, and one panel with the ear split engaged
+        // is what says whether it did.
+        //
+        gint64 t0 = g_get_monotonic_time();
+#endif
+
+        for (i = 0; i < receivers; i++) { rx_begin_off(receiver[i]); }
+
+        for (i = 0; i < receivers; i++) { rx_wait_off(receiver[i]); }
+
+#if RXTX_TIMING
+        t_print("%s: RX->TX shutdown, %d receiver(s): %lld us\n", __func__,
+                receivers, (long long)(g_get_monotonic_time() - t0));
+#endif
+      }
+
       for (i = 0; i < receivers; i++) {
         receiver[i]->displaying = 0;
         if (!radio_is_remote) {
-          //
-          // wait for slew-down only if this is the last receiver
-          // to be switched off
-          //
-          rx_off(receiver[i], SET(i == (receivers - 1)));
           rx_set_displaying(receiver[i]);
         } else {
           send_startstop_rxspectrum(cl_sock_tcp, i, 0);
@@ -2441,11 +2494,14 @@ void radio_set_tune(int state) {
     schedule_high_priority();
     if (state) {
       if (!duplex) {
+        //
+        // Both phases before anything else, for the reason in rxtx().
+        //
+        for (int i = 0; i < receivers; i++) { rx_begin_off(receiver[i]); }
+
+        for (int i = 0; i < receivers; i++) { rx_wait_off(receiver[i]); }
+
         for (int i = 0; i < receivers; i++) {
-          //
-          // wait for slew-down only if this is the last receiver
-          //
-          rx_off(receiver[i], SET(i == (receivers - 1)));
           receiver[i]->displaying = 0;
           rx_set_displaying(receiver[i]);
           schedule_high_priority();

--- a/src/receiver.c
+++ b/src/receiver.c
@@ -1473,7 +1473,7 @@ void rx_change_sample_rate(RECEIVER *rx, int sample_rate) {
       g_free(rx->audio_output_buffer);
     }
     rx->audio_output_buffer = g_new(double, 2 * rx->output_samples);
-    rx_off(rx, 1);
+    rx_off(rx);
     rx_set_analyzer(rx);
     SetInputSamplerate(rx->id, sample_rate);
     SetEXTANBSamplerate (rx->id, sample_rate);
@@ -1645,19 +1645,42 @@ void rx_set_analyzer(RECEIVER *rx) {
   rx->analyzer_initializing = 1;
 }
 
-void rx_off(const RECEIVER *rx, int wait) {
+//
+// Switching a receiver off is two things, and they are worth issuing apart.
+//
+// SetChannelState(id, 0, ...) only asks: it raises the down-slew and flush
+// flags. The ramp itself runs inside fexchange0(), so the channel finishes
+// stopping only while it is still being fed, and WaitChannelFlush() is what
+// waits for that. Two receivers stopped one at a time therefore wait out
+// two ramps in sequence, although the channels are independent and would
+// ramp down perfectly well together.
+//
+// So: rx_begin_off() on every receiver, then rx_wait_off() on every
+// receiver, and the cost is the longest ramp rather than the sum. rx_off()
+// is both, for the callers that only have one receiver to stop.
+//
+// THE INVARIANT, which is not obvious and which a previous attempt at this
+// broke: no channel may be restarted with a flush still pending. Shut one
+// down without waiting and then stop its IQ, and it is left half-down; the
+// pending flush fires after the restart, resets "exchange", and fexchange0()
+// stops exchanging for good with the DSP thread waiting on Sem_BuffReady.
+// That is the hang that the unconditional wait here was guarding against.
+// Waiting for every channel before any of them is restarted keeps the same
+// guarantee - it is the serialisation that was never needed, not the wait.
+//
+void rx_begin_off(const RECEIVER *rx) {
   ASSERT_SERVER();
-  //
-  // switch receiver OFF.
-  // if (wait)  wait until slew-down completed; else return immediately
-  // ATTENTION:
-  // when using 2 RX, it regularly happened that after RX1 being shut down
-  // with wait==0 and RX2 with wait==1, upon restart of the receivers
-  // the WDSP RX1 thread was hanging in wdspmain (waiting for Sem_BuffReady).
-  // Therefore we do the wait in any case until we know what is going on.
-  // This slightly slows down the RX/TX transition when using 2RX.
-  //
-  SetChannelState(rx->id, 0, 1);
+  SetChannelState(rx->id, 0, 0);
+}
+
+void rx_wait_off(const RECEIVER *rx) {
+  ASSERT_SERVER();
+  WaitChannelFlush(rx->id, 100);
+}
+
+void rx_off(const RECEIVER *rx) {
+  rx_begin_off(rx);
+  rx_wait_off(rx);
 }
 
 void rx_on(const RECEIVER *rx) {

--- a/src/receiver.h
+++ b/src/receiver.h
@@ -290,7 +290,13 @@ extern void   rx_get_pixels(RECEIVER *rx);
 extern void   rx_get_meter(RECEIVER *rx);
 extern void   rx_frequency_changed(const RECEIVER *rx);
 extern void   rx_mode_changed(RECEIVER *rx);
-extern void   rx_off(const RECEIVER *rx, int wait);
+//
+// Stopping a receiver in two phases, so that several can ramp down at once
+// rather than one after another. See rx_begin_off() for the ordering rule.
+//
+extern void   rx_begin_off(const RECEIVER *rx);
+extern void   rx_wait_off(const RECEIVER *rx);
+extern void   rx_off(const RECEIVER *rx);
 extern void   rx_on(const RECEIVER *rx);
 extern void   rx_reconfigure(RECEIVER *rx, int height);
 extern void   rx_restore_state(RECEIVER *rx);

--- a/wdsp/channel.c
+++ b/wdsp/channel.c
@@ -257,12 +257,54 @@ void SetAllRates (int channel, int in_rate, int dsp_rate, int out_rate)
 	}
 }
 
+// Wait for a channel that has been asked to stop to finish flushing.
+//
+// Shutting a channel down is not instantaneous and is not self-driving.
+// SetChannelState(channel, 0, ...) only raises slew.downflag and flushflag;
+// the ramp itself runs inside fexchange0(), and only when it completes does
+// that code reset "exchange" and release Sem_Flush, waking this channel's
+// flushChannel() thread to do the flush and clear flushflag. So a channel
+// finishes stopping only while it is still being fed, and this is what waits
+// for that to happen.
+//
+// Split out of SetChannelState() so that a caller stopping several channels
+// can raise the flags on all of them first and wait afterwards, rather than
+// waiting for each in turn: the channels ramp down concurrently - each has
+// its own flushChannel() thread, its own Sem_Flush and its own critical
+// sections - so the cost becomes the longest ramp rather than the sum.
+//
+// A second SetChannelState(channel, 0, 1) cannot serve as that wait: the
+// "state != state" test below makes it a silent no-op once the channel is
+// already stopped.
+//
+// Safe to call when nothing is pending; returns at once. Returns 1 if the
+// channel flushed, 0 if it timed out - in which case the flags are forced
+// down, exactly as before.
+PORT
+int WaitChannelFlush (int channel, int timeout_ms)
+{
+	IOB a = ch[channel].iob.pc;
+	int count = 0;
+	while (_InterlockedAnd (&ch[channel].flushflag, 1) && count < timeout_ms)
+	{
+		Sleep(1);
+		count++;
+	}
+	if (count >= timeout_ms)
+	{
+		InterlockedBitTestAndReset (&ch[channel].exchange, 0);
+		InterlockedBitTestAndReset (&ch[channel].flushflag, 0);
+		InterlockedBitTestAndReset (&a->slew.downflag, 0);
+		return 0;
+	}
+	return 1;
+}
+
 PORT
 int SetChannelState (int channel, int state, int dmode)
 {
 	IOB a = ch[channel].iob.pc;
 	int prior_state = ch[channel].state;
-	int count = 0;
 	const int timeout = 100;
 	if (ch[channel].state != state)
 	{
@@ -272,20 +314,7 @@ int SetChannelState (int channel, int state, int dmode)
 		case 0:
 			InterlockedBitTestAndSet (&a->slew.downflag, 0);
 			InterlockedBitTestAndSet (&ch[channel].flushflag, 0);
-			if (dmode)
-			{
-				while (_InterlockedAnd (&ch[channel].flushflag, 1) && count < timeout)
-				{
-					Sleep(1);
-					count++;
-				}
-			}
-			if (count >= timeout)
-			{
-				InterlockedBitTestAndReset (&ch[channel].exchange, 0);
-				InterlockedBitTestAndReset (&ch[channel].flushflag, 0);
-				InterlockedBitTestAndReset (&a->slew.downflag, 0);
-			}
+			if (dmode) WaitChannelFlush (channel, timeout);
 			break;
 		case 1:
 			InterlockedBitTestAndSet (&a->slew.upflag, 0);

--- a/wdsp/channel.h
+++ b/wdsp/channel.h
@@ -80,5 +80,6 @@ PORT void SetOutputSamplerate (int channel, int samplerate);
 PORT void SetAllRates (int channel, int in_rate, int dsp_rate, int out_rate);
 
 PORT int SetChannelState (int channel, int state, int dmode);
+PORT int WaitChannelFlush (int channel, int timeout_ms);
 
 #endif

--- a/wdsp/wdsp.h
+++ b/wdsp/wdsp.h
@@ -328,6 +328,7 @@ extern void SetDSPSamplerate (int channel, int dsp_rate);
 extern void SetOutputSamplerate (int channel, int out_rate);
 extern void SetAllRates (int channel, int in_rate, int dsp_rate, int out_rate);
 extern int SetChannelState (int channel, int state, int dmode);
+extern int WaitChannelFlush (int channel, int timeout_ms);
 extern void SetChannelTDelayUp (int channel, double time);
 extern void SetChannelTSlewUp (int channel, double time);
 extern void SetChannelTDelayDown (int channel, double time);


### PR DESCRIPTION
I'm working on a binaural diversity feature and along the way my coding agent & I ran into this area of optimization which does improve RX -TX turnaround times (beneficial in CW !) when both Receivers are in use  and tests out ok here. 

I have tested this on protocol 1 ( HL2 ) and protocol 2 (brick3)   as well as client - server.  

**Stop receivers in parallel across the RX/TX transition**

  Each receiver's WDSP shutdown is currently waited out one after another, so the RX/TX turnaround costs one slew-down per receiver, in sequence. rxtx()'s own header puts the transition at "about 30 ± 10
  msec … dominated by the WDSP slew-downs", and with two receivers that is paid twice.

  It lands where it is felt: radio_set_mox() sets mox only after rxtx() returns, and iambic.c fires ext_radio_set_mox(1) then busy-waits on mox before the first element and its sidetone. The whole of
  rxtx() sits between the key going down and the first thing the operator hears.

  rx_off() carries a wait argument it has ignored since the workaround above it went in — the one whose comment ends "we do the wait in any case until we know what is going on."

  What is going on is that stopping a channel is not self-driving. SetChannelState(id, 0, ·) only raises slew.downflag and flushflag. The ramp itself runs inside fexchange0(), and only when it completes
  does that code reset exchange and release Sem_Flush, waking the channel's own flushChannel() thread to clear flushflag — which is what the wait watches. So a channel finishes stopping only while 
  something keeps feeding it. Shut one down without waiting and then stop its IQ, and it is left half-down: the pending flush fires after the restart, resets exchange, and fexchange0() stops exchanging for
  good with the DSP thread parked on Sem_BuffReady. That is the hang.

  So the hazard is restarting a channel with a flush pending — not stopping channels concurrently. The channels are independent: each has its own flushChannel() thread, its own Sem_Flush, and its own
  csDSP/csEXCH.

  The patch is two phases — rx_begin_off() on every receiver, then rx_wait_off() on every receiver. Nothing is restarted until all have flushed, so the guarantee the unconditional wait was protecting is
  kept; what goes is the serialization it never needed. rx_off() keeps its name for single-receiver callers and loses the argument that did nothing.

  Measured with RXTX_TIMING, medians of three transitions:

  one receiver          16.9 ms      the control
  two receivers         16.8 ms      ×1.00
  one panel, ear split  15.8 ms      ×0.94

  One receiver is the control, because there the two-phase and serialized forms are the same code path. Two receivers now cost what one costs — about 17 ms off every turnaround with a second receiver
  running.

  Tested on the radio, both protocols, at one/two receivers and with a second receiver driven as an audio path: repeated cycling, the tune path, and a rate change followed by keying in each of the nine
  combinations, plus CW by ear, MIDI keying, PureSignal, and a remote client. No hang anywhere.

  Two commits: the wdsp half first — additive, SetChannelState(ch, 0, 1) calls the extracted WaitChannelFlush() with the same timeout and the same force-down on expiry, so existing callers are unchanged
  bit for bit — then the piHPSDR half.

