### PR TITLE
P2: do not bypass the RX band-pass filter of an unused ADC.

### DIFF
--- a/src/new_protocol.c
+++ b/src/new_protocol.c
@@ -928,7 +928,15 @@ static void new_protocol_high_priority(void) {
     //
     // ADC0 band pass
     //
-    BPFfreq = 0LL;
+    //
+    // Default to the active receiver's frequency, not zero: zero is also
+    // the "bypass" sentinel tested below, so an ADC that no receiver is
+    // assigned to would have its band-pass filter opened across the whole
+    // spectrum rather than tracking the band in use. Only an explicit
+    // adc[].filter_bypass may ask for the bypass. The G2E case above
+    // already defaults this way.
+    //
+    BPFfreq = DDCfrequency[rxvfo];
     if (receivers > 1) {
       if (receiver[othervfo]->adc == 0) {
         BPFfreq = DDCfrequency[othervfo];   // Take frequency of non-active receiver
@@ -961,7 +969,14 @@ static void new_protocol_high_priority(void) {
     //
     // ADC1 band pass
     //
-    BPFfreq = 0LL;
+    //
+    // Default to the active receiver's frequency - see the ADC0 case
+    // above. This is the one that bites in practice: with a single
+    // receiver on ADC0 and DIVERSITY off, nothing below selects a
+    // frequency for ADC1, so its band-pass filter was bypassed and the
+    // ADC saw the whole spectrum.
+    //
+    BPFfreq = DDCfrequency[rxvfo];
     if (receivers > 1) {
       if (receiver[othervfo]->adc == 1) {
         BPFfreq = DDCfrequency[othervfo];   // Take frequency of non-active receiver


### PR DESCRIPTION
In the Saturn/Orion2 branch of new_protocol_high_priority(), BPFfreq is initialised to zero, and zero is also the value that selects ALEX_ANAN7000_RX_BYPASS_BPF in the test below. When no receiver is assigned to an ADC, DIVERSITY is off and adc[].filter_bypass is clear, nothing overwrites that initial zero, so the band-pass filter is bypassed rather than left on the band in use.

This is reached in an ordinary single-receiver setup: with RX1 on ADC0 and DIVERSITY off, neither the "receivers > 1" branch nor the receiver[rxvfo]->adc == 1 branch fires, and ADC1's filter is bypassed so the ADC sees the whole spectrum. On a G2/Saturn, this produces frequent "ADC1 overload" warnings with nothing on the panadapter to explain them
- the energy that clips the converter is out of band

Default BPFfreq to the active receiver's frequency instead, which is what the NEW_DEVICE_G2E branch a few lines above already does for the single-ADC case. The explicit bypass is unaffected, because adc[].filter_bypass assigns zero after the default.

Behaviour is unchanged whenever a receiver is assigned to the ADC, when DIVERSITY is enabled, or when filter_bypass is set; only the previously-bypassed case moves. DDCfrequency[] is filled unconditionally for both indices earlier in the same function, so the new default is always valid.

Both arms are changed. ADC0 is reachable the same way if the only running receiver is moved to ADC1.

